### PR TITLE
Add applicationUri example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Below is a basic example of configuring a sensor and sending an event, as well a
 ### Basic example
 
 ```ts
+// Set application URI if using DLQ
+Caliper.settings.applicationUri = 'https://example.org';
+
 // Initialize Caliper sensor
 const sensor = new Sensor('http://example.org/sensors/1');
 
@@ -119,6 +122,9 @@ a flag to enable/disable event validation, and a `Record` of objects that implem
 as an alternative to using the `Sensor.registerClient` function.
 
 ```ts
+// Set application URI if using DLQ
+Caliper.settings.applicationUri = 'https://example.org';
+
 const sensor1 = new Sensor('http://example.org/sensors/1');
 
 // With SensorConfig

--- a/il-catalog-info.yaml
+++ b/il-catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1beta1
+kind: Component
+metadata:
+  name: caliper-ts
+  description: Caliper sensor library for sending RAD events with Typescript projects
+  title: caliper-ts
+  tags:
+    - typescript
+  annotations:
+    github.com/project-slug: ImagineLearning/caliper-ts
+spec:
+  type: library
+  lifecycle: production
+  owner: reporting-and-dashboards

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@imaginelearning/caliper-ts",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"description": "Reference implementation of the Caliper Sensor API written in TypeScript",
 	"author": "Imagine Learning",
 	"license": "MIT",


### PR DESCRIPTION
This is required for the DLQ service to know where the events originate, otherwise they come across as `Unknown`